### PR TITLE
Enable Tests that require the App Engine SDK

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,5 +4,9 @@
 	<classpathentry kind="con" path="com.google.appengine.eclipse.core.GAE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/com.google.appengine.eclipse.sdkbundle_1.8.7/appengine-java-sdk-1.8.7/lib/impl/appengine-api.jar"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/com.google.appengine.eclipse.sdkbundle_1.8.7/appengine-java-sdk-1.8.7/lib/impl/appengine-api-labs.jar"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/com.google.appengine.eclipse.sdkbundle_1.8.7/appengine-java-sdk-1.8.7/lib/impl/appengine-api-stubs.jar"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/com.google.appengine.eclipse.sdkbundle_1.8.7/appengine-java-sdk-1.8.7/lib/testing/appengine-testing.jar"/>
 	<classpathentry kind="output" path="war/WEB-INF/classes"/>
 </classpath>


### PR DESCRIPTION
This pull request adds the App Engine Java testing utilities to `.classpath` file, making it possible to run tests that require the App Engine SDK (specifically, the data storage API) in order to work properly.

Note that this assumes you are using version 1.8.7 of the App Engine SDK (or at least have it installed). If this breaks the app or tests for you let me know and I'll show you how to fix the problem.
